### PR TITLE
Corrige links relacionadas

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,27 +306,27 @@
         <br/>
         &#9679; <a href="http://www.estadao.com.br/noticias/nacional,estadao-dados-une-transparencia-e-interatividade,872163,0.htm">Estadão Dados une transparência e interatividade</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/01/basometro-10-analises-da-fidelidade-partidaria-do-governo-dilma/">BASÔMETRO: 10 análises sobre a fidelidade partidária do governo Dilma</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/basometro-10-analises-da-fidelidade-partidaria-do-governo-dilma/">BASÔMETRO: 10 análises sobre a fidelidade partidária do governo Dilma</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/01/analise-o-nao-voto-e-a-confianca-nos-deputados-federais/">ANÁLISE: O não voto e a confiança nos deputados federais</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/analise-o-nao-voto-e-a-confianca-nos-deputados-federais/">ANÁLISE: O não voto e a confiança nos deputados federais</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/05/29/o-governismo-do-psd/">ANÁLISE: O governismo do PSD</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/o-governismo-do-psd/">ANÁLISE: O governismo do PSD</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/05/25/artigo-quem-da-as-cartas-nas-bancadas-partidarias/">ANÁLISE: Quem dá as cartas nas bancadas partidárias?</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/artigo-quem-da-as-cartas-nas-bancadas-partidarias/">ANÁLISE: Quem dá as cartas nas bancadas partidárias?</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/06/sobre-disciplinas-e-fidelidades-partidarias/">ANÁLISE: Sobre disciplinas e fidelidades partidárias</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/sobre-disciplinas-e-fidelidades-partidarias/">ANÁLISE: Sobre disciplinas e fidelidades partidárias</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/08/o-governismo-como-estrategia-dominante-na-politica-brasileira/">ANÁLISE: O governismo como estratégia dominante na política brasileira </a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/o-governismo-como-estrategia-dominante-na-politica-brasileira/">ANÁLISE: O governismo como estratégia dominante na política brasileira </a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/12/analise-conflitos-e-consensos-do-pt-e-psdb/">ANÁLISE: Conflitos e consensos do PT e PSDB</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/analise-conflitos-e-consensos-do-pt-e-psdb/">ANÁLISE: Conflitos e consensos do PT e PSDB</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/15/analise-partidos-de-adesao/">ANÁLISE: Partidos de adesão</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/analise-partidos-de-adesao/">ANÁLISE: Partidos de adesão</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/19/psdb-postura-contradicoes-ambiguidades/">ANÁLISE: PSDB: postura, contradições, ambiguidades</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/psdb-postura-contradicoes-ambiguidades/">ANÁLISE: PSDB: postura, contradições, ambiguidades</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/22/analise-oposicao-em-mutacao-evidencias-do-basometro/">ANÁLISE: Oposição em Mutação? Evidências do Basômetro</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/analise-oposicao-em-mutacao-evidencias-do-basometro/">ANÁLISE: Oposição em Mutação? Evidências do Basômetro</a>
         <br/>
-        &#9679; <a href="http://blogs.estadao.com.br/radar-politico/2012/06/26/entre-a-paixao-e-a-razao-politica-argumentos-sobre-a-alianca-pp-e-pt-em-sao-paulo/">ANÁLISE: Entre a paixão e a razão política: argumentos sobre a aliança PP e PT em São Paulo</a>
+        &#9679; <a href="http://politica.estadao.com.br/blogs/radar-politico/entre-a-paixao-e-a-razao-politica-argumentos-sobre-a-alianca-pp-e-pt-em-sao-paulo/">ANÁLISE: Entre a paixão e a razão política: argumentos sobre a aliança PP e PT em São Paulo</a>
     <br/>
   </div>
   <br clear="all" >


### PR DESCRIPTION
Os links que estavam em http://blogs.estadao.com.br/radar-politico/%Y/%m/%d/*
mudaram para http://politica.estadao.com.br/blogs/radar-politico/*

Os links em http://politica.estadao.com.br/blogs/radar-politico/basometro-10-analises-da-fidelidade-partidaria-do-governo-dilma/ também estão todos quebrados por causa disso.
